### PR TITLE
Perf improvements

### DIFF
--- a/src/spectralDCM_LFP_MTK.jl
+++ b/src/spectralDCM_LFP_MTK.jl
@@ -110,7 +110,7 @@ np = sum(tunable_parameters(fullmodel); init=0) do par
 end
 # indices2 = Dict(:dspars => collect(1:np))
 indices2 = (dspars = collect(1:np), u = idx_u, m = idx_measurement, sts = idx_sts)
-indices = Dict()
+indices = Dict{Symbol, Vector{Int}}()
 # Noise parameter mean
 modelparam[:lnα] = zeros(Float64, 2, nr);         # intrinsic fluctuations, ln(α) as in equation 2 of Friston et al. 2014 
 n = length(modelparam[:lnα]);

--- a/src/utils/MTK_utilities.jl
+++ b/src/utils/MTK_utilities.jl
@@ -472,6 +472,9 @@ function addnontunableparams(paramlist::Vector{T}, sys) where T
     return completeparamlist
 end
 
+getnontunableparams(sys) = [Symbolics.getdefaultval(p) for p ∈ parameters(sys) if !istunable(p)]
+
+
 function changetune(model, parlist)
     parstochange = keys(parlist)
     p_new = map(parameters(model)) do p


### PR DESCRIPTION
Before (3 regions):
```julia
julia> @benchmark let state = copy($state)
           for iter in 1:128
               state.iter = iter
               run_spDCM_iteration!(state, setup)
               if iter >= 4
                   criterion = state.dF[end-3:end] .< setup.tolerance
                   if all(criterion)
                       break
                   end
               end
           end
       end
BenchmarkTools.Trial: 3 samples with 1 evaluation per sample.
 Range (min … max):  1.918 s …  1.936 s  ┊ GC (min … max):  9.50% … 11.87%
 Time  (median):     1.934 s             ┊ GC (median):    11.72%
 Time  (mean ± σ):   1.929 s ± 9.951 ms  ┊ GC (mean ± σ):  11.03% ±  1.33%

  █                                                  █   █  
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁█ ▁
  1.92 s        Histogram: frequency by time        1.94 s <

 Memory estimate: 3.05 GiB, allocs estimate: 6251169.
```
After:
```julia
julia> @benchmark let state = copy($state)
           for iter in 1:128
               state.iter = iter
               run_spDCM_iteration!(state, setup)
               if iter >= 4
                   criterion = state.dF[end-3:end] .< setup.tolerance
                   if all(criterion)
                       break
                   end
               end
           end
       end
BenchmarkTools.Trial: 15 samples with 1 evaluation per sample.
 Range (min … max):  317.589 ms … 382.707 ms  ┊ GC (min … max):  4.26% … 15.34%
 Time  (median):     350.435 ms               ┊ GC (median):    15.65%
 Time  (mean ± σ):   352.803 ms ±  16.024 ms  ┊ GC (mean ± σ):  14.62% ±  3.03%

  ▁                  ▁▁▁     ▁ █▁▁         ▁ █   ▁▁           ▁  
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁███▁▁▁▁▁█▁███▁▁▁▁▁▁▁▁▁█▁█▁▁▁██▁▁▁▁▁▁▁▁▁▁▁█ ▁
  318 ms           Histogram: frequency by time          383 ms <

 Memory estimate: 715.54 MiB, allocs estimate: 1575919.
```